### PR TITLE
Introduce Collator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,19 +3,19 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.4.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed May 18 08:34:14 BST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/src/main/java/com/heetch/countrypicker/CountryPickerDialog.java
+++ b/src/main/java/com/heetch/countrypicker/CountryPickerDialog.java
@@ -10,7 +10,6 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 
 import java.text.Collator;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -29,6 +28,7 @@ public class CountryPickerDialog extends AppCompatDialog {
     /**
      * You can set the heading country in headingCountryCode to show
      * your favorite country as the head of the list
+     *
      * @param context
      * @param callbacks
      * @param headingCountryCode
@@ -42,10 +42,12 @@ public class CountryPickerDialog extends AppCompatDialog {
         Collections.sort(countries, new Comparator<Country>() {
             @Override
             public int compare(Country country1, Country country2) {
-                return new Locale(getContext().getResources().getConfiguration().locale.getLanguage(),
-                        country1.getIsoCode()).getDisplayCountry().compareTo(
-                        new Locale(getContext().getResources().getConfiguration().locale.getLanguage(),
-                                country2.getIsoCode()).getDisplayCountry());
+                final Locale locale = getContext().getResources().getConfiguration().locale;
+                final Collator collator = Collator.getInstance(locale);
+                collator.setStrength(Collator.PRIMARY);
+                return collator.compare(
+                        new Locale(locale.getLanguage(), country1.getIsoCode()).getDisplayCountry(),
+                        new Locale(locale.getLanguage(), country2.getIsoCode()).getDisplayCountry());
             }
         });
     }

--- a/src/main/java/com/heetch/countrypicker/Utils.java
+++ b/src/main/java/com/heetch/countrypicker/Utils.java
@@ -1,15 +1,11 @@
 package com.heetch.countrypicker;
 
-import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
-import org.apache.http.HttpEntity;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -45,7 +41,7 @@ public class Utils {
     }
 
     public static List<Country> parseCountries(JSONObject jsonCountries) {
-        List<Country> countries = new ArrayList<Country>();
+        List<Country> countries = new ArrayList<>();
         Iterator<String> iter = jsonCountries.keys();
 
         while (iter.hasNext()) {


### PR DESCRIPTION
Use a collator so that accented names are correctly ordered. In English this means that the Aland Islands are now positioned more correctly at the top of the list. The other locales this is even more critical.

Also upgraded to use the latest versions.
